### PR TITLE
Explictly do not support Windows, avoid error codes

### DIFF
--- a/chalk.go
+++ b/chalk.go
@@ -131,34 +131,3 @@ func (s *style) WithTextStyle(textStyle TextStyle) Style {
 	s.textStyle = textStyle
 	return s
 }
-
-var (
-	// Colors
-
-	Black      = Color{0}
-	Red        = Color{1}
-	Green      = Color{2}
-	Yellow     = Color{3}
-	Blue       = Color{4}
-	Magenta    = Color{5}
-	Cyan       = Color{6}
-	White      = Color{7}
-	ResetColor = Color{9}
-
-	// Text Styles
-
-	Bold          = TextStyle{1, 22}
-	Dim           = TextStyle{2, 22}
-	Italic        = TextStyle{3, 23}
-	Underline     = TextStyle{4, 24}
-	Inverse       = TextStyle{7, 27}
-	Hidden        = TextStyle{8, 28}
-	Strikethrough = TextStyle{9, 29}
-
-	Reset = &style{
-		foreground: ResetColor,
-		background: ResetColor,
-	}
-
-	emptyTextStyle = TextStyle{}
-)

--- a/chalk_windows.go
+++ b/chalk_windows.go
@@ -124,34 +124,3 @@ func (s *style) WithTextStyle(textStyle TextStyle) Style {
 	s.textStyle = textStyle
 	return s
 }
-
-var (
-	// Colors
-
-	Black      = Color{0}
-	Red        = Color{1}
-	Green      = Color{2}
-	Yellow     = Color{3}
-	Blue       = Color{4}
-	Magenta    = Color{5}
-	Cyan       = Color{6}
-	White      = Color{7}
-	ResetColor = Color{9}
-
-	// Text Styles
-
-	Bold          = TextStyle{1, 22}
-	Dim           = TextStyle{2, 22}
-	Italic        = TextStyle{3, 23}
-	Underline     = TextStyle{4, 24}
-	Inverse       = TextStyle{7, 27}
-	Hidden        = TextStyle{8, 28}
-	Strikethrough = TextStyle{9, 29}
-
-	Reset = &style{
-		foreground: ResetColor,
-		background: ResetColor,
-	}
-
-	emptyTextStyle = TextStyle{}
-)

--- a/chalk_windows.go
+++ b/chalk_windows.go
@@ -24,7 +24,6 @@ func (c Color) Color(val string) string {
 }
 
 func (c Color) String() string {
-	// return fmt.Sprintf("\u001b[%dm", 30+c.value)
 	return ""
 }
 
@@ -48,10 +47,6 @@ type TextStyle struct {
 
 // TextStyle styles the given string using the desired text style.
 func (t TextStyle) TextStyle(val string) string {
-	// if t == emptyTextStyle {
-	// 	return val
-	// }
-	// return fmt.Sprintf("%s%s%s", t.start, val, t.stop)
 	return val
 }
 
@@ -59,7 +54,6 @@ func (t TextStyle) TextStyle(val string) string {
 // text styles must be wrapped around the text they are meant to style.
 // As such, use TextStyle() or Style.Style() instead.
 func (t TextStyle) String() string {
-	// return fmt.Sprintf("%s%s", t.start, t.stop)
 	return ""
 }
 
@@ -111,14 +105,10 @@ func (s *style) WithForeground(col Color) Style {
 }
 
 func (s *style) String() string {
-	// var toReturn string
-	// toReturn = fmt.Sprintf("\u001b[%dm", 40+s.background.Value())
-	// return toReturn + fmt.Sprintf("\u001b[%dm", 30+s.foreground.Value())
 	return ""
 }
 
 func (s *style) Style(val string) string {
-	// return fmt.Sprintf("%s%s%s", s, s.textStyle.TextStyle(val), Reset)
 	return ""
 }
 

--- a/chalk_windows.go
+++ b/chalk_windows.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package chalk
 
 import "fmt"
@@ -22,11 +20,12 @@ func (c Color) Value() int {
 // (whatever the previous background color was, it is
 // left alone).
 func (c Color) Color(val string) string {
-	return fmt.Sprintf("%s%s%s", c, val, ResetColor)
+	return val
 }
 
 func (c Color) String() string {
-	return fmt.Sprintf("\u001b[%dm", 30+c.value)
+	// return fmt.Sprintf("\u001b[%dm", 30+c.value)
+	return ""
 }
 
 // NewStyle creates a style with a foreground of the
@@ -49,17 +48,19 @@ type TextStyle struct {
 
 // TextStyle styles the given string using the desired text style.
 func (t TextStyle) TextStyle(val string) string {
-	if t == emptyTextStyle {
-		return val
-	}
-	return fmt.Sprintf("%s%s%s", t.start, val, t.stop)
+	// if t == emptyTextStyle {
+	// 	return val
+	// }
+	// return fmt.Sprintf("%s%s%s", t.start, val, t.stop)
+	return val
 }
 
 // NOTE: this function specifically does not work as desired because
 // text styles must be wrapped around the text they are meant to style.
 // As such, use TextStyle() or Style.Style() instead.
 func (t TextStyle) String() string {
-	return fmt.Sprintf("%s%s", t.start, t.stop)
+	// return fmt.Sprintf("%s%s", t.start, t.stop)
+	return ""
 }
 
 // NewStyle creates a style starting with the current TextStyle
@@ -110,13 +111,15 @@ func (s *style) WithForeground(col Color) Style {
 }
 
 func (s *style) String() string {
-	var toReturn string
-	toReturn = fmt.Sprintf("\u001b[%dm", 40+s.background.Value())
-	return toReturn + fmt.Sprintf("\u001b[%dm", 30+s.foreground.Value())
+	// var toReturn string
+	// toReturn = fmt.Sprintf("\u001b[%dm", 40+s.background.Value())
+	// return toReturn + fmt.Sprintf("\u001b[%dm", 30+s.foreground.Value())
+	return ""
 }
 
 func (s *style) Style(val string) string {
-	return fmt.Sprintf("%s%s%s", s, s.textStyle.TextStyle(val), Reset)
+	// return fmt.Sprintf("%s%s%s", s, s.textStyle.TextStyle(val), Reset)
+	return ""
 }
 
 func (s *style) Foreground(col Color) {

--- a/vars.go
+++ b/vars.go
@@ -1,0 +1,32 @@
+package chalk
+
+var (
+	// Colors
+
+	Black      = Color{0}
+	Red        = Color{1}
+	Green      = Color{2}
+	Yellow     = Color{3}
+	Blue       = Color{4}
+	Magenta    = Color{5}
+	Cyan       = Color{6}
+	White      = Color{7}
+	ResetColor = Color{9}
+
+	// Text Styles
+
+	Bold          = TextStyle{1, 22}
+	Dim           = TextStyle{2, 22}
+	Italic        = TextStyle{3, 23}
+	Underline     = TextStyle{4, 24}
+	Inverse       = TextStyle{7, 27}
+	Hidden        = TextStyle{8, 28}
+	Strikethrough = TextStyle{9, 29}
+
+	Reset = &style{
+		foreground: ResetColor,
+		background: ResetColor,
+	}
+
+	emptyTextStyle = TextStyle{}
+)


### PR DESCRIPTION
The Windows console does not support the same ANSI character codes, so when they are printed out it ends up looking like gibberish characters.

This PR avoids this by simply returning blank strings for the functions. This removes all color syntax for windows builds only.

Explanation for setting up platform conditional builds is here: 
https://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ttacon/chalk/6)
<!-- Reviewable:end -->
